### PR TITLE
feat: add an option to change font and icon display size

### DIFF
--- a/src/logisim_src/gui/prefs/DisplayScaleOptions.java
+++ b/src/logisim_src/gui/prefs/DisplayScaleOptions.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2010, Carl Burch. License information is located in the
+ * logisim_src.Main source code and at www.cburch.com/logisim/. */
+
+package logisim_src.gui.prefs;
+
+import java.awt.BorderLayout;
+import java.awt.Font;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import logisim_src.prefs.AppPreferences;
+
+class DisplayScaleOptions extends OptionsPanel {
+    private JLabel restart = new JLabel();
+    private PrefOptionList displayScale;
+
+    public DisplayScaleOptions(PreferencesFrame window) {
+        super(window);
+
+        displayScale = new PrefOptionList(AppPreferences.DISPLAY_SCALE,
+                Strings.getter("Display Scale"),
+                new PrefOption[]{
+                        new PrefOption(AppPreferences.SCALE_100, Strings.getter("100% (Default)")),
+                        new PrefOption(AppPreferences.SCALE_125, Strings.getter("125%")),
+                        new PrefOption(AppPreferences.SCALE_150, Strings.getter("150%"))
+                });
+
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(displayScale.getJLabel(), BorderLayout.LINE_START);
+        panel.add(displayScale.getJComboBox(), BorderLayout.CENTER);
+        panel.add(restart, BorderLayout.PAGE_END);
+        restart.setFont(restart.getFont().deriveFont(Font.ITALIC));
+        JPanel panel2 = new JPanel();
+        panel2.add(panel);
+
+        setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
+        add(Box.createGlue());
+        add(panel2);
+        add(Box.createGlue());
+
+    }
+
+    @Override
+    public String getTitle() {
+        return Strings.get("displayScaleTitle");
+    }
+
+    @Override
+    public String getHelpText() {
+        return Strings.get("displayScaleHelp");
+    }
+
+    @Override
+    public void localeChanged() {
+        displayScale.localeChanged();
+        restart.setText(Strings.get("restartLabel"));
+    }
+
+}

--- a/src/logisim_src/gui/prefs/PreferencesFrame.java
+++ b/src/logisim_src/gui/prefs/PreferencesFrame.java
@@ -89,6 +89,7 @@ public class PreferencesFrame extends LFrame {
 				new TemplateOptions(this),
 				new IntlOptions(this),
 				new WindowOptions(this),
+				new DisplayScaleOptions(this),
 				new LayoutOptions(this),
 				new ExperimentalOptions(this),
 		};

--- a/src/logisim_src/gui/start/Startup.java
+++ b/src/logisim_src/gui/start/Startup.java
@@ -256,6 +256,8 @@ public class Startup {
 			AppPreferences.clear();
 		}
 
+		System.setProperty("flatlaf.uiScale", AppPreferences.DISPLAY_SCALE.get().toString());
+
 		try {
 			UIManager.setLookAndFeel(new FlatDarculaLaf());
 		} catch (Exception ex) { }

--- a/src/logisim_src/prefs/AppPreferences.java
+++ b/src/logisim_src/prefs/AppPreferences.java
@@ -77,7 +77,15 @@ public class AppPreferences {
 					Direction.EAST.toString(), Direction.WEST.toString(),
 					TOOLBAR_DOWN_MIDDLE, TOOLBAR_HIDDEN },
 				Direction.NORTH.toString()));
-	
+
+	// Display Scale preferences
+	public static final String SCALE_100 = "1.0";
+	public static final String SCALE_125 = "1.25";
+	public static final String SCALE_150 = "1.5";
+	public static final PrefMonitor<String> DISPLAY_SCALE
+		= create(new PrefMonitorStringOpts("displayScale",
+			new String[] { SCALE_100, SCALE_125, SCALE_150}, SCALE_100));
+
 	// Layout preferences
 	public static final String ADD_AFTER_UNCHANGED = "unchanged";
 	public static final String ADD_AFTER_EDIT = "edit";

--- a/src/resources/logisim/en/prefs.properties
+++ b/src/resources/logisim/en/prefs.properties
@@ -35,6 +35,11 @@ windowToolbarLocation = Toolbar location:
 windowToolbarHidden = Hidden
 windowToolbarDownMiddle = Down middle
 
+# DisplayScaleOptions.java
+displayScaleTitle = Display Scale
+displayScaleHelp = Change font size and icon scale
+restartLabel = Restart Logisim for changes to take effect.
+
 # LayoutOptions.java
 layoutTitle = Layout
 layoutHelp = Configure behavior of layout editor


### PR DESCRIPTION
Implement a new 'Display Scale' tab to Preferences allowing users to set scaling factors (1.0 - 1.5) that changes parts of the UI, such as menu bar size, font size, and icon size. Requires restart to take effect. This change implements #4.